### PR TITLE
Get two-way listener working

### DIFF
--- a/MatlabApp/Program.cs
+++ b/MatlabApp/Program.cs
@@ -14,15 +14,19 @@ namespace MatlabApp
         /// <param name="args">Requires three arguments for db, secret and root</param>
         static void Main(string[] args)
         {
-            if (args.Length != 3)
+            if (args.Length < 2 || args.Length > 3)
             {
-                Console.WriteLine("Invalid command arguments: path secret root");
+                Console.WriteLine("Invalid command arguments: path secret [all]");
+                Console.WriteLine("  path - the name of the firebase database; eg 'dev-financial-canvas-studio'");
+                Console.WriteLine("  secret - the authentication secret for the firebase database");
+                Console.WriteLine("  all - 'all'/'current' if the api should update all dashboards or the current one; default is 'all'");
                 return;
             }
             var path = args[0];
             var secret = args[1];
-            var root = args[2];
-            var listener = new FirebaseListener(path, secret, root);
+            var updateAll = (args.Length <= 3 || args[2] == "all");
+
+            var listener = new FirebaseListener(path, secret, updateAll);
             try
             {
                 listener.Listen();
@@ -36,10 +40,10 @@ namespace MatlabApp
                     waiting = !(key.Key == ConsoleKey.Q);
                 }
             }
-            catch (Exception EX)
+            catch (Exception ex)
             {
-                Console.WriteLine("Error in listener");
-                Console.WriteLine(EX.Message);
+                Console.Error.WriteLine("Error in listener");
+                Console.Error.WriteLine(ex.Message);
             }
             finally
             {


### PR DESCRIPTION
Redo of the two-way mode using the .net api
Wait for 250ms before actually firing the updates, as that means we've unpacked the entire callback.
Move the data produced by two way to the nodes _studio and _canvas signifying where the data comes from.
Added the ability to reset the model with a reload and force update of the external sources.
After updating all the tunables are deleted.
Additional runtime setting to update all external sources and not just the one caller. This still requires path and secret from the command line.

To work properly, the data should be sent [makes everything up to date], a state saved and then the data should be re-sent.  This makes sure the correct state file is given to firebase.